### PR TITLE
composer: add craue-formflow-bundle into dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     ],
     "require": {
         "friendsofsymfony/user-bundle": "~1.3",
+        "craue/formflow-bundle": "~2.1",
         "php": ">=5.3.2"
     },
     "autoload": {


### PR DESCRIPTION
Hi,

I'm currently installing a fresh NMM portal from scratch without any other additional bundles.

I get an error about a missing reference : 

`
[Symfony\Component\DependencyInjection\Exception\RuntimeException]
  The parent definition "craue.form.flow" defined for definition "sam.registration.form.flow" does not exist.
`

So instead of adding this bundle in the global composer, I suggest to do it in the concerned bundle, so you can manage the version yourself.

I didn't add the related documentation about the bundle declaration in AppKernel.php file because there is no README in this bundle. Tell me if you want me to create it and add this step.

PS: we were using version 2.1.5 for craue but I added ~2.1.0 because I don't know what version you use.