### PR TITLE
made symfony3 compatible

### DIFF
--- a/Controller/UserController.php
+++ b/Controller/UserController.php
@@ -161,7 +161,7 @@ class UserController extends AbstractController
     /**
      * Displays a form to edit profil of current user.
      */
-    public function editProfilAction()
+    public function editProfilAction(Request $request)
     {
         $app = $this->get('canal_tp_sam.application.finder')->getCurrentApp();
         $id = $this->get('security.context')->getToken()->getUser()->getId();
@@ -172,7 +172,7 @@ class UserController extends AbstractController
             $user
         );
 
-        $form->handleRequest($this->getRequest());
+        $form->handleRequest($request);
         if ($form->isValid()) {
             $this->editProfilProcessForm($user);
         }

--- a/Form/DataTransformer/RoleToUserApplicationRoleTransformer.php
+++ b/Form/DataTransformer/RoleToUserApplicationRoleTransformer.php
@@ -3,19 +3,24 @@
 namespace CanalTP\SamEcoreUserManagerBundle\Form\DataTransformer;
 
 use Symfony\Component\Form\DataTransformerInterface;
-use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 
 class RoleToUserApplicationRoleTransformer implements DataTransformerInterface
 {
     private $om;
-    private $securityContext;
+    private $authorizationChecker;
+    private $currentUser;
 
-    public function __construct(ObjectManager $om, SecurityContext $securityContext)
-    {
+    public function __construct(
+        ObjectManager $om,
+        TokenStorageInterface $tokenStorage,
+        AuthorizationCheckerInterface $authorizationChecker
+    ) {
         $this->om = $om;
-        $this->currentUser = $securityContext->getToken()->getUser();
-        $this->securityContext = $securityContext;
+        $this->currentUser = $tokenStorage->getToken()->getUser();
+        $this->authorizationChecker = $authorizationChecker;
     }
 
     public function transform($user)
@@ -37,7 +42,7 @@ class RoleToUserApplicationRoleTransformer implements DataTransformerInterface
         $userRoles = array();
 
         foreach ($submitedRoles as $role) {
-            if ($this->securityContext->isGranted('BUSINESS_MANAGE_USER')
+            if ($this->authorizationChecker->isGranted('BUSINESS_MANAGE_USER')
                 || array_key_exists($role->getId(), $officialRoles)) {
                 $userRoles[] = $role;
             }

--- a/Form/Type/ConfirmationFormType.php
+++ b/Form/Type/ConfirmationFormType.php
@@ -13,7 +13,7 @@ namespace CanalTP\SamEcoreUserManagerBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class ConfirmationFormType extends AbstractType
 {
@@ -33,7 +33,7 @@ class ConfirmationFormType extends AbstractType
             );
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -41,10 +41,5 @@ class ConfirmationFormType extends AbstractType
                 'intention'  => 'confirmation',
             )
         );
-    }
-
-    public function getName()
-    {
-        return 'canaltp_user_confirmation';
     }
 }

--- a/Form/Type/CustomerType.php
+++ b/Form/Type/CustomerType.php
@@ -4,25 +4,25 @@ namespace CanalTP\SamEcoreUserManagerBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Doctrine\ORM\EntityManager;
 
 class CustomerType extends AbstractType
 {
     private $em;
-    private $securityContext;
+    private $tokenStorage;
 
-    public function __construct(EntityManager $entityManager, SecurityContext $securityContext)
+    public function __construct(EntityManager $entityManager, TokenStorageInterface $tokenStorage)
     {
         $this->em = $entityManager;
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
     }
 
     private function initCustomerField(FormBuilderInterface $builder)
     {
         $repository = $this->em->getRepository('CanalTPSamCoreBundle:Customer');
-        $user = $this->securityContext->getToken()->getUser();
+        $user = $this->tokenStorage->getToken()->getUser();
         $isSuperAdmin = $user->hasRole('ROLE_SUPER_ADMIN');
 
         $builder->add('customer', 'entity', array(
@@ -51,7 +51,7 @@ class CustomerType extends AbstractType
         $this->initCustomerField($builder);
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -60,10 +60,5 @@ class CustomerType extends AbstractType
                 'csrf_protection' => false
             )
         );
-    }
-
-    public function getName()
-    {
-        return 'assign_customer';
     }
 }

--- a/Form/Type/ProfilFormType.php
+++ b/Form/Type/ProfilFormType.php
@@ -54,12 +54,4 @@ class ProfilFormType extends BaseRegistrationFormType
             ]
         );
     }
-
-    /**
-     * @return string
-     */
-    public function getName()
-    {
-        return 'edit_user_profil';
-    }
 }

--- a/Form/Type/RoleType.php
+++ b/Form/Type/RoleType.php
@@ -4,11 +4,9 @@ namespace CanalTP\SamEcoreUserManagerBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
-use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Doctrine\ORM\EntityManager;
 use CanalTP\SamEcoreUserManagerBundle\Form\DataTransformer\RoleToUserApplicationRoleTransformer;
-use CanalTP\SamEcoreUserManagerBundle\Form\Type\RoleByApplicationType;
 
 class RoleType extends AbstractType
 {
@@ -44,7 +42,7 @@ class RoleType extends AbstractType
         $this->initRoleField($builder);
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -52,10 +50,5 @@ class RoleType extends AbstractType
                 'csrf_protection' => false
             )
         );
-    }
-
-    public function getName()
-    {
-        return 'assign_role';
     }
 }

--- a/Form/Type/UserType.php
+++ b/Form/Type/UserType.php
@@ -4,7 +4,7 @@ namespace CanalTP\SamEcoreUserManagerBundle\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\Email;
@@ -84,7 +84,7 @@ class UserType extends AbstractType
         );
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(
@@ -92,10 +92,5 @@ class UserType extends AbstractType
                 'csrf_protection' => false
             )
         );
-    }
-
-    public function getName()
-    {
-        return 'create_user';
     }
 }

--- a/Processor/RoleProcessor.php
+++ b/Processor/RoleProcessor.php
@@ -3,7 +3,7 @@
 namespace CanalTP\SamEcoreUserManagerBundle\Processor;
 
 use FOS\UserBundle\Model\UserManagerInterface;
-use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * Cette classe a pour but de gerer les differentes données
@@ -14,18 +14,18 @@ use Symfony\Component\Security\Core\SecurityContext;
  * */
 class RoleProcessor
 {
-    private $securityContext;
+    private $authorizationChecker;
     private $userManager;
 
     /**
      * __construct
      *
-     * @param SecurityContext      $securityContext
-     * @param UserManagerInterface $userManager
+     * @param AuthorizationCheckerInterface $authorizationChecker
+     * @param UserManagerInterface          $userManager
      */
-    public function __construct(SecurityContext $securityContext, UserManagerInterface $userManager)
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker, UserManagerInterface $userManager)
     {
-        $this->securityContext = $securityContext;
+        $this->authorizationChecker = $authorizationChecker;
         $this->userManager = $userManager;
     }
 
@@ -40,7 +40,7 @@ class RoleProcessor
     {
         $roleSuperAdmin = 'ROLE_SUPER_ADMIN';
 
-        if ($this->securityContext->isGranted($roleSuperAdmin)) {
+        if ($this->authorizationChecker->isGranted($roleSuperAdmin)) {
             $entities = $this->userManager->findPaginateUsers($page);
         } else {
             $entities = $this->userManager->findPaginateUsersExcludingRole($roleSuperAdmin, $page);
@@ -60,7 +60,7 @@ class RoleProcessor
     {
         $roleSuperAdmin = 'ROLE_SUPER_ADMIN';
 
-        if ($this->securityContext->isGranted($roleSuperAdmin)) {
+        if ($this->authorizationChecker->isGranted($roleSuperAdmin)) {
             $count = $this->userManager->countUsers();
         } else {
             $count = $this->userManager->countUsersExcludingRole($roleSuperAdmin);

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,20 +8,21 @@
         <parameter key="canaltp_user.confirmation.form.name">canaltp_user_confirmation_form</parameter>
         <parameter key="canaltp_user.confirmation.form.type">canaltp_user_confirmation</parameter>
         <parameter key="sam.registration.step_one.type.class">CanalTP\SamEcoreUserManagerBundle\Form\Type\RegistrationStepOneFormType</parameter>
-        <parameter key="sam_role_by_application.type.class">CanalTP\SamEcoreUserManagerBundle\Form\Type\RoleByApplicationType</parameter>
     </parameters>
 
     <services>
-        <service id="sam_role_by_application.type" class="%sam_role_by_application.type.class%">
+        <service id="sam_role_by_application.type" class="CanalTP\SamEcoreUserManagerBundle\Form\Type\RoleByApplicationType">
             <argument type="service" id="doctrine.orm.entity_manager" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="security.authorization_checker" />
         </service>
 
         <service
             id="sam.registration.assign_role.role_to_user_application_role_transformer.data_transformer"
             class="CanalTP\SamEcoreUserManagerBundle\Form\DataTransformer\RoleToUserApplicationRoleTransformer">
             <argument type="service" id="doctrine.orm.entity_manager" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
+            <argument type="service" id="security.authorization_checker" />
         </service>
 
         <service id="sam.user_provider.email" class="CanalTP\SamEcoreUserManagerBundle\Security\EmailProvider" public="false">
@@ -29,12 +30,12 @@
         </service>
 
         <service id="sam.registration.form.type" class="CanalTP\SamEcoreUserManagerBundle\Form\Type\UserType">
-            <tag name="form.type" alias="create_user" />
+            <tag name="form.type" />
         </service>
 
         <service id="sam.registration.assign_customer.form.type" class="CanalTP\SamEcoreUserManagerBundle\Form\Type\CustomerType">
             <argument type="service" id="doctrine.orm.entity_manager" />
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.token_storage" />
         </service>
 
         <service id="sam.registration.assign_role.form.type" class="CanalTP\SamEcoreUserManagerBundle\Form\Type\RoleType">
@@ -83,7 +84,7 @@
         </service>
 
         <service id="canaltp.role.processor" class="CanalTP\SamEcoreUserManagerBundle\Processor\RoleProcessor">
-            <argument type="service" id="security.context" />
+            <argument type="service" id="security.authorization_checker" />
             <argument type="service" id="fos_user.user_manager" />
         </service>
 


### PR DESCRIPTION
fix 
```
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
| #  | Usage                                                                                                                                             | Line | Comment                                                                                          |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-user-manager-bundle/Form/Type/UserType.php                                                                                                                               |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
| 1  | Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface                                                             | 87   | since version 2.6, to be removed in 3.0. Use {@link OptionsResolver} instead.                    |
| 2  | Overriding deprecated method CanalTP\SamEcoreUserManagerBundle\Form\Type\UserType->setDefaultOptions()                                            | 87   | since version 2.7, to be renamed in 3.0.                                                         |
|    |                                                                                                                                                   |      |  Use the method configureOptions instead. This method will be                                    |
|    |                                                                                                                                                   |      |  added to the FormTypeInterface with Symfony 3.0.                                                |
| 3  | Overriding deprecated method CanalTP\SamEcoreUserManagerBundle\Form\Type\UserType->getName()                                                      | 97   | Deprecated since Symfony 2.8, to be removed in Symfony 3.0.                                      |
|    |                                                                                                                                                   |      |  Use the fully-qualified class name of the type instead.                                         |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-user-manager-bundle/Form/Type/ProfilFormType.php                                                                                                                         |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
| 4  | Overriding deprecated method CanalTP\SamEcoreUserManagerBundle\Form\Type\ProfilFormType->getName()                                                | 61   | Deprecated since Symfony 2.8, to be removed in Symfony 3.0.                                      |
|    |                                                                                                                                                   |      |  Use the fully-qualified class name of the type instead.                                         |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-user-manager-bundle/Form/Type/CustomerType.php                                                                                                                           |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
| 5  | Calling deprecated method Symfony\Component\Security\Core\SecurityContext->getToken()                                                             | 25   | since version 2.6, to be removed in 3.0. Use TokenStorageInterface::getToken() instead.          |
|    |                                                                                                                                                   |      |                                                                                                  |
|    |                                                                                                                                                   |      | {@inheritdoc}                                                                                    |
| 6  | Using deprecated class Symfony\Component\Security\Core\SecurityContext                                                                            | 16   | since version 2.6, to be removed in 3.0.                                                         |
| 7  | Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface                                                             | 54   | since version 2.6, to be removed in 3.0. Use {@link OptionsResolver} instead.                    |
| 8  | Overriding deprecated method CanalTP\SamEcoreUserManagerBundle\Form\Type\CustomerType->setDefaultOptions()                                        | 54   | since version 2.7, to be renamed in 3.0.                                                         |
|    |                                                                                                                                                   |      |  Use the method configureOptions instead. This method will be                                    |
|    |                                                                                                                                                   |      |  added to the FormTypeInterface with Symfony 3.0.                                                |
| 9  | Overriding deprecated method CanalTP\SamEcoreUserManagerBundle\Form\Type\CustomerType->getName()                                                  | 65   | Deprecated since Symfony 2.8, to be removed in Symfony 3.0.                                      |
|    |                                                                                                                                                   |      |  Use the fully-qualified class name of the type instead.                                         |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-user-manager-bundle/Form/Type/ConfirmationFormType.php                                                                                                                   |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
| 10 | Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface                                                             | 36   | since version 2.6, to be removed in 3.0. Use {@link OptionsResolver} instead.                    |
| 11 | Overriding deprecated method CanalTP\SamEcoreUserManagerBundle\Form\Type\ConfirmationFormType->setDefaultOptions()                                | 36   | since version 2.7, to be renamed in 3.0.                                                         |
|    |                                                                                                                                                   |      |  Use the method configureOptions instead. This method will be                                    |
|    |                                                                                                                                                   |      |  added to the FormTypeInterface with Symfony 3.0.                                                |
| 12 | Overriding deprecated method CanalTP\SamEcoreUserManagerBundle\Form\Type\ConfirmationFormType->getName()                                          | 46   | Deprecated since Symfony 2.8, to be removed in Symfony 3.0.                                      |
|    |                                                                                                                                                   |      |  Use the fully-qualified class name of the type instead.                                         |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-user-manager-bundle/Form/Type/RoleType.php                                                                                                                               |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
| 13 | Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface                                                             | 47   | since version 2.6, to be removed in 3.0. Use {@link OptionsResolver} instead.                    |
| 14 | Overriding deprecated method CanalTP\SamEcoreUserManagerBundle\Form\Type\RoleType->setDefaultOptions()                                            | 47   | since version 2.7, to be renamed in 3.0.                                                         |
|    |                                                                                                                                                   |      |  Use the method configureOptions instead. This method will be                                    |
|    |                                                                                                                                                   |      |  added to the FormTypeInterface with Symfony 3.0.                                                |
| 15 | Overriding deprecated method CanalTP\SamEcoreUserManagerBundle\Form\Type\RoleType->getName()                                                      | 57   | Deprecated since Symfony 2.8, to be removed in Symfony 3.0.                                      |
|    |                                                                                                                                                   |      |  Use the fully-qualified class name of the type instead.                                         |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-user-manager-bundle/Form/Type/RoleByApplicationType.php                                                                                                                  |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
| 16 | Calling deprecated method Symfony\Component\Security\Core\SecurityContext->getToken()                                                             | 26   | since version 2.6, to be removed in 3.0. Use TokenStorageInterface::getToken() instead.          |
|    |                                                                                                                                                   |      |                                                                                                  |
|    |                                                                                                                                                   |      | {@inheritdoc}                                                                                    |
| 17 | Calling deprecated method Symfony\Component\Security\Core\SecurityContext->isGranted()                                                            | 76   | since version 2.6, to be removed in 3.0. Use AuthorizationCheckerInterface::isGranted() instead. |
|    |                                                                                                                                                   |      |                                                                                                  |
|    |                                                                                                                                                   |      | {@inheritdoc}                                                                                    |
| 18 | Using deprecated class Symfony\Component\Security\Core\SecurityContext                                                                            | 22   | since version 2.6, to be removed in 3.0.                                                         |
| 19 | Using deprecated interface Symfony\Component\OptionsResolver\OptionsResolverInterface                                                             | 64   | since version 2.6, to be removed in 3.0. Use {@link OptionsResolver} instead.                    |
| 20 | Overriding deprecated method CanalTP\SamEcoreUserManagerBundle\Form\Type\RoleByApplicationType->setDefaultOptions()                               | 64   | since version 2.7, to be renamed in 3.0.                                                         |
|    |                                                                                                                                                   |      |  Use the method configureOptions instead. This method will be                                    |
|    |                                                                                                                                                   |      |  added to the FormTypeInterface with Symfony 3.0.                                                |
| 21 | Overriding deprecated method CanalTP\SamEcoreUserManagerBundle\Form\Type\RoleByApplicationType->getName()                                         | 93   | Deprecated since Symfony 2.8, to be removed in Symfony 3.0.                                      |
|    |                                                                                                                                                   |      |  Use the fully-qualified class name of the type instead.                                         |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-user-manager-bundle/Form/DataTransformer/RoleToUserApplicationRoleTransformer.php                                                                                        |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
| 22 | Calling deprecated method Symfony\Component\Security\Core\SecurityContext->getToken()                                                             | 17   | since version 2.6, to be removed in 3.0. Use TokenStorageInterface::getToken() instead.          |
|    |                                                                                                                                                   |      |                                                                                                  |
|    |                                                                                                                                                   |      | {@inheritdoc}                                                                                    |
| 23 | Calling deprecated method Symfony\Component\Security\Core\SecurityContext->isGranted()                                                            | 40   | since version 2.6, to be removed in 3.0. Use AuthorizationCheckerInterface::isGranted() instead. |
|    |                                                                                                                                                   |      |                                                                                                  |
|    |                                                                                                                                                   |      | {@inheritdoc}                                                                                    |
| 24 | Using deprecated class Symfony\Component\Security\Core\SecurityContext                                                                            | 14   | since version 2.6, to be removed in 3.0.                                                         |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-user-manager-bundle/Controller/UserController.php                                                                                                                        |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
| 25 | Calling deprecated method Symfony\Bundle\FrameworkBundle\Controller\Controller->getRequest()                                                      | 175  | since version 2.4, to be removed in 3.0.                                                         |
|    |                                                                                                                                                   |      |  Ask Symfony to inject the Request object into your controller                                   |
|    |                                                                                                                                                   |      |  method instead by type hinting it in the method's signature.                                    |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-user-manager-bundle/Processor/RoleProcessor.php                                                                                                                          |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
| 26 | Calling deprecated method Symfony\Component\Security\Core\SecurityContext->isGranted()                                                            | 43   | since version 2.6, to be removed in 3.0. Use AuthorizationCheckerInterface::isGranted() instead. |
|    |                                                                                                                                                   |      |                                                                                                  |
|    |                                                                                                                                                   |      | {@inheritdoc}                                                                                    |
| 27 | Calling deprecated method Symfony\Component\Security\Core\SecurityContext->isGranted()                                                            | 63   | since version 2.6, to be removed in 3.0. Use AuthorizationCheckerInterface::isGranted() instead. |
|    |                                                                                                                                                   |      |                                                                                                  |
|    |                                                                                                                                                   |      | {@inheritdoc}                                                                                    |
| 28 | Using deprecated class Symfony\Component\Security\Core\SecurityContext                                                                            | 26   | since version 2.6, to be removed in 3.0.                                                         |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
|    | /home/dquintanel/sources/canaltp/nmm-ihm.local.canaltp.fr/vendor/canaltp/sam-ecore-user-manager-bundle/Features/Context/FeatureContext.php                                                                                                                  |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+
| 29 | Using deprecated interface Behat\Behat\Context\SnippetAcceptingContext by class CanalTP\SamEcoreUserManagerBundle\Features\Context\FeatureContext | 10   | will be removed in 4.0. Use --snippets-for CLI option instead                                    |
+----+---------------------------------------------------------------------------------------------------------------------------------------------------+------+--------------------------------------------------------------------------------------------------+

```


Relates to https://jira.kisio.org/browse/GN-65