### PR TITLE
Do not show unable to find object error message on the profil page

### DIFF
--- a/Controller/UserController.php
+++ b/Controller/UserController.php
@@ -176,6 +176,7 @@ class UserController extends AbstractController
      */
     public function editProfilAction(Request $request)
     {
+        $this->container->get('session')->getFlashBag()->clear();
         $app = $this->get('canal_tp_sam.application.finder')->getCurrentApp();
         $id = $this->get('security.context')->getToken()->getUser()->getId();
         $userManager = $this->container->get('fos_user.user_manager');


### PR DESCRIPTION
# Description

This PR fixes bug to do not show unable to find object error message on the profil page

## Reference (optional)

Reference link:bot-1483