### PR TITLE
Bugfix bot 1557 handling emails with accents

### DIFF
--- a/Form/Type/UserType.php
+++ b/Form/Type/UserType.php
@@ -7,7 +7,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\NotBlank;
-use Symfony\Component\Validator\Constraints\Email;
+use CanalTP\SamEcoreUserManagerBundle\Validator\Constraints\EmailRFC2822;
 
 class UserType extends AbstractType
 {
@@ -16,70 +16,74 @@ class UserType extends AbstractType
         $builder->add(
             'username',
             'text',
-            array(
+            [
                 'label' => 'form.username',
-                'attr' => array(
+                'attr' => [
                     'class' => 'col-md-4',
                     'placeholder' => 'enter username'
-                ),
+                ],
                 'translation_domain' => 'FOSUserBundle'
-            )
+            ]
         );
 
         $builder->add(
             'firstname',
             'text',
-            array(
+            [
                 'label' => 'form.firstname',
-                'attr' => array(
+                'attr' => [
                     'class' => 'col-md-4',
                     'placeholder' => 'enter firstname'
-                ),
+                ],
                 'translation_domain' => 'FOSUserBundle',
-                'constraints' => array(
-                        new NotBlank(array('groups' => 'flow_registration_step1')),
-                        new Length(array('groups' => 'flow_registration_step1', 'min' => 3, 'max' => 255))
-                )
-            )
+                'constraints' => [
+                    new NotBlank(['groups' => 'flow_registration_step1']),
+                    new Length(['groups' => 'flow_registration_step1', 'min' => 3, 'max' => 255])
+                ]
+            ]
         );
 
         $builder->add(
             'lastname',
             'text',
-            array(
+            [
                 'label' => 'form.lastname',
-                'attr' => array(
+                'attr' => [
                     'class' => 'col-md-4',
                     'placeholder' => 'enter lastname'
-                ),
+                ],
                 'translation_domain' => 'FOSUserBundle',
-                'constraints' => array(
-                        new NotBlank(array('groups' => 'flow_registration_step1')),
-                        new Length(array('groups' => 'flow_registration_step1', 'min' => 3, 'max' => 255))
-                )
-            )
+                'constraints' => [
+                    new NotBlank(['groups' => 'flow_registration_step1']),
+                    new Length(['groups' => 'flow_registration_step1', 'min' => 3, 'max' => 255])
+                ]
+            ]
         );
 
         $builder->add(
             'email',
             'text',
-            array(
+            [
                 'label' => 'form.email',
-                'attr' => array(
+                'attr' => [
                     'class' => 'col-md-4',
                     'placeholder' => 'enter email'
-                ),
-                'translation_domain' => 'FOSUserBundle'
-            )
+                ],
+                'translation_domain' => 'FOSUserBundle',
+                'constraints' => [
+                    new EmailRFC2822(['groups' => 'flow_registration_step1']),
+                    new NotBlank(['groups' => 'flow_registration_step1']),
+                ]
+            ]
         );
 
         $builder->add(
             'timezone',
             'timezone',
             [
-              'label' => 'form.timezone',
-              'preferred_choices' => array('Europe/Paris'),
-              'translation_domain' => 'FOSUserBundle'
+                'label' => 'form.timezone',
+                'preferred_choices' => ['Europe/Paris'],
+                'translation_domain' => 'FOSUserBundle'
             ]
         );
     }
@@ -87,10 +91,10 @@ class UserType extends AbstractType
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver->setDefaults(
-            array(
+            [
                 'data_class' => 'CanalTP\SamEcoreUserManagerBundle\Entity\User',
                 'csrf_protection' => false
-            )
+            ]
         );
     }
 

--- a/Form/Type/UserType.php
+++ b/Form/Type/UserType.php
@@ -22,7 +22,6 @@ class UserType extends AbstractType
                     'class' => 'col-md-4',
                     'placeholder' => 'enter username'
                 ],
-                'translation_domain' => 'FOSUserBundle'
             ]
         );
 
@@ -35,7 +34,6 @@ class UserType extends AbstractType
                     'class' => 'col-md-4',
                     'placeholder' => 'enter firstname'
                 ],
-                'translation_domain' => 'FOSUserBundle',
                 'constraints' => [
                     new NotBlank(['groups' => 'flow_registration_step1']),
                     new Length(['groups' => 'flow_registration_step1', 'min' => 3, 'max' => 255])
@@ -52,7 +50,6 @@ class UserType extends AbstractType
                     'class' => 'col-md-4',
                     'placeholder' => 'enter lastname'
                 ],
-                'translation_domain' => 'FOSUserBundle',
                 'constraints' => [
                     new NotBlank(['groups' => 'flow_registration_step1']),
                     new Length(['groups' => 'flow_registration_step1', 'min' => 3, 'max' => 255])
@@ -69,7 +66,6 @@ class UserType extends AbstractType
                     'class' => 'col-md-4',
                     'placeholder' => 'enter email'
                 ],
-                'translation_domain' => 'FOSUserBundle',
                 'constraints' => [
                     new EmailRFC2822(['groups' => 'flow_registration_step1']),
                     new NotBlank(['groups' => 'flow_registration_step1']),
@@ -83,7 +79,6 @@ class UserType extends AbstractType
             [
                 'label' => 'form.timezone',
                 'preferred_choices' => ['Europe/Paris'],
-                'translation_domain' => 'FOSUserBundle'
             ]
         );
     }
@@ -93,7 +88,8 @@ class UserType extends AbstractType
         $resolver->setDefaults(
             [
                 'data_class' => 'CanalTP\SamEcoreUserManagerBundle\Entity\User',
-                'csrf_protection' => false
+                'csrf_protection' => false,
+                'translation_domain' => 'FOSUserBundle'
             ]
         );
     }

--- a/Resources/translations/FOSUserBundle.en.yml
+++ b/Resources/translations/FOSUserBundle.en.yml
@@ -112,3 +112,5 @@ form:
     password_confirmation: "Verification :"
     new_password: "New Password :"
     new_password_confirmation: "Verification :"
+    error:
+        email_rfc2822: "This email address does not comply with RFC 2822"

--- a/Resources/translations/FOSUserBundle.fr.yml
+++ b/Resources/translations/FOSUserBundle.fr.yml
@@ -112,3 +112,5 @@ form:
     password_confirmation: "Vérification :"
     new_password: "Nouveau mot de passe :"
     new_password_confirmation: "Vérification :"
+
+"This email address does not comply with RFC 2822" : "Cette adresse e-mail n'est pas conforme aux normes RFC 2822"

--- a/Resources/translations/FOSUserBundle.fr.yml
+++ b/Resources/translations/FOSUserBundle.fr.yml
@@ -112,5 +112,5 @@ form:
     password_confirmation: "Vérification :"
     new_password: "Nouveau mot de passe :"
     new_password_confirmation: "Vérification :"
-
-"This email address does not comply with RFC 2822" : "Cette adresse e-mail n'est pas conforme aux normes RFC 2822"
+    error:
+        email_rfc2822: "Cette adresse e-mail n'est pas conforme aux normes RFC 2822"

--- a/Tests/Unit/Constraints/EmailRFC2822Test.php
+++ b/Tests/Unit/Constraints/EmailRFC2822Test.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace CanalTP\SamEcoreUserManagerBundle\Tests\Unit\Constraints;
+
+use CanalTP\SamEcoreUserManagerBundle\Tests\Unit\UnitTestCase;
+use CanalTP\SamEcoreUserManagerBundle\Validator\Constraints\EmailRFC2822;
+
+class EmailRFC2822Test extends UnitTestCase
+{
+    /**
+     * @var EmailRFC2822
+     */
+    private $constraint;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->constraint = new EmailRFC2822();
+    }
+
+    public function testConstraintClass()
+    {
+        $this->assertInstanceOf('Symfony\Component\Validator\Constraints\Email', $this->constraint);
+    }
+
+    public function testMessage()
+    {
+        $this->assertEquals('This email address does not comply with RFC 2822', $this->constraint->message);
+    }
+}

--- a/Tests/Unit/Constraints/EmailRFC2822ValidatorTest.php
+++ b/Tests/Unit/Constraints/EmailRFC2822ValidatorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace CanalTP\SamEcoreUserManagerBundle\Tests\Unit\Constraints;
+
+use CanalTP\SamEcoreUserManagerBundle\Validator\Constraints\EmailRFC2822;
+use CanalTP\SamEcoreUserManagerBundle\Validator\Constraints\EmailRFC2822Validator;
+
+class EmailRFC2822ValidatorTest extends ValidatorTestCase
+{
+    /**
+     * @var EmailRFC2822Validator
+     */
+    private $validator;
+
+    /**
+     * @var EmailRFC2822
+     */
+    private $constraint;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->constraint = new EmailRFC2822();
+        $this->validator = new EmailRFC2822Validator();
+    }
+
+    protected function getValidatorInstance()
+    {
+        return $this->validator;
+    }
+
+    public function testValidationOK()
+    {
+        $validator = $this->initValidator();
+
+        $validator->validate('email@mail.com', $this->constraint);
+        $validator->validate('email@local.host', $this->constraint);
+    }
+
+    public function testValidationKO()
+    {
+        $validator = $this->initValidator($this->constraint->message);
+        $validator->validate('émail@local.host', $this->constraint);
+    }
+}

--- a/Tests/Unit/Constraints/ValidatorTestCase.php
+++ b/Tests/Unit/Constraints/ValidatorTestCase.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace CanalTP\SamEcoreUserManagerBundle\Tests\Unit\Constraints;
+
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Context\ExecutionContext;
+use Symfony\Component\Validator\Violation\ConstraintViolationBuilder;
+use CanalTP\SamEcoreUserManagerBundle\Tests\Unit\UnitTestCase;
+
+abstract class ValidatorTestCase extends UnitTestCase
+{
+    /**
+     * Initialise the validator.
+     *
+     * @param string|null $expectedMessage
+     *
+     * @return ConstraintValidator
+     */
+    protected function initValidator($expectedMessage = null)
+    {
+        $builder = $this->getMockBuilder(ConstraintViolationBuilder::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['addViolation'])
+            ->getMock();
+
+        $context = $this->getMockBuilder(ExecutionContext::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['buildViolation'])
+            ->getMock();
+
+        if ($expectedMessage) {
+            $builder->expects($this->once())->method('addViolation');
+            $context
+                ->expects($this->once())
+                ->method('buildViolation')
+                ->with($this->equalTo($expectedMessage))
+                ->willReturn($builder);
+        } else {
+            $context->expects($this->never())->method('buildViolation');
+        }
+
+        $validator = $this->getValidatorInstance();
+        $validator->initialize($context);
+
+        return $validator;
+    }
+
+    /**
+     * @return ConstraintValidator
+     */
+    abstract protected function getValidatorInstance();
+}

--- a/Tests/Unit/UnitTestCase.php
+++ b/Tests/Unit/UnitTestCase.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace CanalTP\SamEcoreUserManagerBundle\Tests\Unit;
+
+class UnitTestCase extends \PHPUnit_Framework_TestCase
+{
+
+}

--- a/Validator/Constraints/EmailRFC2822.php
+++ b/Validator/Constraints/EmailRFC2822.php
@@ -10,5 +10,5 @@ use Symfony\Component\Validator\Constraints\Email;
  */
 class EmailRFC2822 extends Email
 {
-    public $message = 'This email address does not comply with RFC 2822';
+    public $message = 'form.error.email_rfc2822';
 }

--- a/Validator/Constraints/EmailRFC2822.php
+++ b/Validator/Constraints/EmailRFC2822.php
@@ -1,0 +1,14 @@
+<?php
+namespace CanalTP\SamEcoreUserManagerBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Email;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ */
+class EmailRFC2822 extends Email
+{
+    public $message = 'This email address does not comply with RFC 2822';
+}

--- a/Validator/Constraints/EmailRFC2822Validator.php
+++ b/Validator/Constraints/EmailRFC2822Validator.php
@@ -1,0 +1,30 @@
+<?php
+namespace CanalTP\SamEcoreUserManagerBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Constraints\EmailValidator;
+use Swift_Mime_Grammar;
+
+/**
+ * @Annotation
+ */
+class EmailRFC2822Validator extends EmailValidator
+{
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$constraint instanceof EmailRFC2822) {
+            throw new UnexpectedTypeException($constraint, EmailRFC2822::class);
+        }
+
+        parent::validate($value, $constraint);
+
+        $grammar = new Swift_Mime_Grammar();
+        if (!preg_match('/^'.$grammar->getDefinition('addr-spec').'$/D', $value)) {
+            $this->buildViolation($constraint->message)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(EmailRFC2822::INVALID_FORMAT_ERROR)
+                ->addViolation();
+        }
+    }
+}


### PR DESCRIPTION
As swiftmailer uses RFC2822 standard, we should use the same standard in user form.

Reference : BOT-1557